### PR TITLE
To from epoch fix

### DIFF
--- a/stsauth.py
+++ b/stsauth.py
@@ -367,8 +367,7 @@ def to_epoch(dt):
     Returns:
         seconds since epoch for dt
     """
-    dt = dt.replace(tzinfo=None)
-    return (dt - datetime(1970, 1, 1)).total_seconds()
+    return dt.strftime('%s')
 
 
 def from_epoch(seconds):

--- a/tests/test_stsauth.py
+++ b/tests/test_stsauth.py
@@ -29,7 +29,6 @@ class TestSTSAuth(TestCase):
 
     def test_sts_auth(self):
         # ipdb.set_trace()
-        print("test print")
         self.assertEquals(1, 1)
 
 

--- a/tests/test_stsauth.py
+++ b/tests/test_stsauth.py
@@ -6,6 +6,9 @@ except ImportError:
     from mock import MagicMock
 
 from stsauth import STSAuth
+from stsauth import from_epoch, to_epoch
+
+from datetime import datetime, timedelta
 
 
 class TestSTSAuth(TestCase):
@@ -26,4 +29,13 @@ class TestSTSAuth(TestCase):
 
     def test_sts_auth(self):
         # ipdb.set_trace()
+        print("test print")
         self.assertEquals(1, 1)
+
+
+class TestToFromEpoch(TestCase):
+    def test_to_from_epoch(self):
+        time_delta = timedelta(seconds=1)
+        datetime_now = datetime.now()
+        util_func_now = from_epoch(to_epoch(datetime.now()))
+        self.assertTrue(abs((util_func_now - datetime_now)) < time_delta)


### PR DESCRIPTION
**Testing code and fix for to_epoch function**

When I was writing testing code, I found that using to_epoch caused a 5
hour difference in the time. I've added the testing code and the fix. I
have pushed this separately from the other testing code I've been
working on since this required a fix.

I don't think this would cause any noticeable errors. It would just cause
the program to request a new sts authorization even though the current
one was still valid.